### PR TITLE
update 'sudo' syntax to 'become'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   local_action: >
     command wget -N -P "{{oracle_jdk_download_dir}}" --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" http://download.oracle.com/otn-pub/java/jdk/{{oracle_jdk_package_subdir}}/{{oracle_jdk_package}}
   tags: download
-  sudo: no
+  become: no
 
 - name: "{{oracle_jdk_installation_dir}} must exist"
   file:


### PR DESCRIPTION
fixes deprecated syntax warning, the become syntax deprecates the old sudo/su specific syntax beginning in Ansible 1.9.
